### PR TITLE
Use Python 3.10 and latest psycopg2

### DIFF
--- a/mlflow-image/Dockerfile
+++ b/mlflow-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.10-slim
 
 # Install python and python dependencies
 RUN pip install pip setuptools --upgrade
@@ -6,7 +6,7 @@ RUN pip install pip setuptools --upgrade
 COPY mlflow_version mlflow_version
 
 # Dependency versions locked at 12-04-2021
-RUN pip install mlflow[extras]==$(cat mlflow_version) psycopg2-binary==2.8.6
+RUN pip install mlflow[extras]==$(cat mlflow_version) psycopg2-binary==2.9.3
 
 # Set the workdir to /var/mlflow, so that /var/mlflow/.mlruns can be mounted if desired
 RUN mkdir /var/mlflow


### PR DESCRIPTION
Just some housekeeping. Merging this will update the 1.24.0 image to use these dependencies.