### PR TITLE
Bumped AWS provider version, locked module version

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -44,7 +44,8 @@ module "security_group" {
   tags = local.tags
 }
 module "db" {
-  source = "terraform-aws-modules/rds/aws"
+  source  = "terraform-aws-modules/rds/aws"
+  version = "4.2.0"
 
   identifier = local.name
 
@@ -62,7 +63,6 @@ module "db" {
   # NOTE: Do NOT use 'user' as the value for 'username' as it throws:
   # "Error creating DB Instance: InvalidParameterValue: MasterUsername
   # user cannot be used as it is a reserved word used by the engine"
-  name                   = local.name
   username               = "superuser"
   create_random_password = true
   random_password_length = 32
@@ -83,8 +83,11 @@ module "db" {
     }
   ]
 
-  subnet_ids = [aws_default_subnet.default_az1.id, aws_default_subnet.default_az2.id]
-  tags       = local.tags
+  create_db_subnet_group = true
+  subnet_ids             = [aws_default_subnet.default_az1.id, aws_default_subnet.default_az2.id]
+  tags                   = local.tags
+
+  storage_encrypted = false
 }
 
 resource "aws_ssm_parameter" "database_password" {

--- a/infrastructure/versions.tf
+++ b/infrastructure/versions.tf
@@ -2,7 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = ">= 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1"
     }
   }
   required_version = ">= 1.0.0"

--- a/mlflow-terraform/main.tf
+++ b/mlflow-terraform/main.tf
@@ -4,8 +4,11 @@ provider "aws" {
   region = "eu-central-1"
 }
 // Mlflow bucket will get a random unique name
-resource "aws_s3_bucket" "mlflow_bucket" {
+resource "aws_s3_bucket_acl" "mlflow_bucket_acl" {
   acl = "private"
+  bucket = aws_s3_bucket.mlflow_bucket.id
+}
+resource "aws_s3_bucket" "mlflow_bucket" {
   tags = {
     Name = "Mlflow model artifacts bucket"
   }

--- a/mlflow-terraform/versions.tf
+++ b/mlflow-terraform/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.4.0"
+      version = ">= 4.0"
     }
   }
   required_version = ">= 1.0.0"


### PR DESCRIPTION
This introduces these changes:

- Bump AWS provider version in the backend terraform to latest
- Bump AWS provider version in the client module to latest'
- Bump the AWS RDS db module version to latest
- Lock the AWS RDS db module version

The reason this was done is because the pipeline started failing due to a breaking change in the RDS module, which required a different AWS provider version.

The implications of this is that all mlflow pipelines have to be bumped to use the latest terraform module, which I will release after this is merged. I will carry out some smoke tests here and there to confirm everything works the way it should.