### PR TITLE
Migrate from KIAM to IRSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [4.0.0] - 2022-08-24
 ### Changed
-- Changed from KIAM auth to IRSA. See https://wiki.dfds.cloud/en/teams/devex/operations/guides/kiam-to-irsa-migration
+- BREAKING: Changed from KIAM auth to IRSA. 
+  See https://wiki.dfds.cloud/en/teams/devex/operations/guides/kiam-to-irsa-migration.
+  KIAM is deprecated and will be removed in the future. We are now using IRSA and ServiceAccounts to assume roles in 
+  AWS. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Changed
+- Changed from KIAM auth to IRSA. See https://wiki.dfds.cloud/en/teams/devex/operations/guides/kiam-to-irsa-migration

--- a/mlflow-terraform/README.md
+++ b/mlflow-terraform/README.md
@@ -1,4 +1,4 @@
-This is an opinionated collection of resouces to be used for the mlflow service. Assuming a database
+This is an opinionated collection of resources to be used for the mlflow service. Assuming a database
 is provisioned centrally in this case.
 
 # Variables

--- a/mlflow-terraform/README.md
+++ b/mlflow-terraform/README.md
@@ -3,5 +3,6 @@ is provisioned centrally in this case.
 
 # Variables
 
-- kubernetes_account_number: The account number to trust to assume your role (ie. account number of
-  KIAM)
+- kubernetes_account_number: The account number of your kubernetes namespace. 
+- kubernetes_namespace: The name of the kubernetes namespace.
+- service_account: OPTIONAL. The name of the service account used in the kubernetes deployment.

--- a/mlflow-terraform/main.tf
+++ b/mlflow-terraform/main.tf
@@ -55,7 +55,8 @@ data "aws_iam_policy_document" "mlflow_server_policy" {
   }
 }
 resource "aws_iam_policy" "mlflow_server_policy" {
-  description = "allows mlflow access to S3"
+  name        = "mlflow-server-policy"
+  description = "Allows mlflow access to S3"
   policy      = data.aws_iam_policy_document.mlflow_server_policy.json
 }
 // Create a random password to be used for the mlflow webserver

--- a/mlflow-terraform/main.tf
+++ b/mlflow-terraform/main.tf
@@ -16,6 +16,7 @@ resource "aws_s3_bucket" "mlflow_bucket" {
 // Create the IAM role to be used by MLFlow to connect to the S3 backend
 resource "aws_iam_role" "mlflow_server_role" {
   assume_role_policy = data.aws_iam_policy_document.irsa_trust_policy.json
+  name = "mlflow-server-role"
 }
 
 data "aws_iam_policy_document" "irsa_trust_policy" {

--- a/mlflow-terraform/main.tf
+++ b/mlflow-terraform/main.tf
@@ -17,7 +17,7 @@ resource "aws_s3_bucket" "mlflow_bucket" {
 resource "aws_iam_role" "mlflow_server_role" {
   assume_role_policy = data.aws_iam_policy_document.irsa_trust_policy.json
 }
-}
+
 data "aws_iam_policy_document" "irsa_trust_policy" {
   statement {
     sid     = ""

--- a/mlflow-terraform/variables.tf
+++ b/mlflow-terraform/variables.tf
@@ -3,3 +3,13 @@ variable "kubernetes_account_number" {
   type        = string
   description = "The account number of the kubernetes cluster that has to assume a role in your capability"
 }
+
+variable "kubernetes_namespace" {
+  type = string
+  description = "The namespace of the kubernetes capability"
+}
+
+variable "service_account" {
+  type = string
+  default = "mlflow"
+}

--- a/mlflow-terraform/variables.tf
+++ b/mlflow-terraform/variables.tf
@@ -1,15 +1,16 @@
 // Declare input variables
 variable "kubernetes_account_number" {
   type        = string
-  description = "The account number of the kubernetes cluster that has to assume a role in your capability"
+  description = "The account number of the kubernetes capability. E.g. '123456789012'"
 }
 
 variable "kubernetes_namespace" {
   type = string
-  description = "The namespace of the kubernetes capability"
+  description = "The namespace of the kubernetes capability. E.g. 'my-capability-jpoxj'."
 }
 
 variable "service_account" {
   type = string
   default = "mlflow"
+  description = "The service account that assumes the mlflow-server-role Role. E.g. 'mlflow'."
 }


### PR DESCRIPTION
Prepare for deprecation of KIAM as a trust relationship method. Moving to IRSA instead. 

This updated terraform module is tested in FreightPricing project. See pipeline run at https://dfds.visualstudio.com/RM%20Analytics/_build/results?buildId=492373&view=results

We need to update the mlflow template repo to make use of this new version. 