### PR TITLE
Add idle_session_timeout to database

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -80,6 +80,12 @@ module "db" {
     {
       name  = "rds.force_ssl"
       value = 1
+    },
+    # Set timeout for idle connections to 24 hours in milliseconds
+    # See https://postgresqlco.nf/doc/en/param/idle_session_timeout/
+    {
+      name = "idle_session_timeout"
+      value = 86400000 
     }
   ]
 


### PR DESCRIPTION
We keep running out of available connections in the mlflow database server. This should release unused connections. 