### PR TITLE
Upgrade to postgres 15

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -54,8 +54,8 @@ module "db" {
 
   # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
   engine         = "postgres"
-  engine_version = "13"
-  family         = "postgres13" # DB parameter group
+  engine_version = "15"
+  family         = "postgres15" # DB parameter group
   instance_class = "db.t3.micro"
 
   allocated_storage = 20


### PR DESCRIPTION
Upgrade the mlflow database server to PostgreSQL 15. 
Before merging this, I will make a backup of the database. 

Motivation: We need a setting for postgres that is not available in v13. 