### PR TITLE
Bump RDS instance size to one size bigger

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -56,7 +56,7 @@ module "db" {
   engine         = "postgres"
   engine_version = "14"
   family         = "postgres14" # DB parameter group
-  instance_class = "db.t3.micro"
+  instance_class = "db.t3.small"
   allocated_storage = 20
 
   # Upgrading engine versions


### PR DESCRIPTION
Trying to alleviate some of the slow performance for our mlflow tracking UI. Maybe the database is just having a hard time? 