### PR TITLE
::set-output is deprecated

### DIFF
--- a/.github/workflows/check-mlflow-release.yml
+++ b/.github/workflows/check-mlflow-release.yml
@@ -10,8 +10,8 @@ jobs:
       - name: Get Latest MLFlow release
         id: mlflow-release
         run: |
-          echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/mlflow/mlflow/releases/latest | jq -r ".tag_name" | sed 's/v//g')
-          echo ::set-output name=current_tag::$(<mlflow-image/mlflow_version)
+          echo release_tag=$(curl -sL https://api.github.com/repos/mlflow/mlflow/releases/latest | jq -r ".tag_name" | sed 's/v//g') >> $GITHUB_OUTPUT
+          echo current_tag=$(<mlflow-image/mlflow_version) >> $GITHUB_OUTPUT
       - name: Update MLFlow version file
         if: (steps.mlflow-release.outputs.current_tag != steps.mlflow-release.outputs.release_tag) && (steps.mlflow-release.outputs.release_tag != 'null')
         env:


### PR DESCRIPTION
Seems this will stop working soon: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Not tested, but this ensures the workflow will keep running in case it is still useful to you.