### PR TITLE
Remove deprecated overwrite option from SSM parameter for database cr…

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -110,5 +110,4 @@ resource "aws_ssm_parameter" "database_password" {
     "username" = module.db.db_instance_username
     "password" = module.db.db_instance_password
   })
-  overwrite = true
 }


### PR DESCRIPTION
Apparently, this deprecated parameter was causing the terraform apply command to freeze.