### PR TITLE
fix(azure-pipelines.yml): extract ECR image tag from mlflow dependenc…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ stages:
       ECR_REPOSITORY: "dna/mlflow"
     steps:
     - bash: |
-        MLFLOW_VERSION=$(grep -oP '(?<=version = ")[^"]+' mlflow-image/pyproject.toml)
+        MLFLOW_VERSION=$(grep -oP 'mlflow\[extras\]~=\K[0-9.]+' mlflow-image/pyproject.toml)
         echo $MLFLOW_VERSION
         echo "##vso[task.setvariable variable=mlflow_tag;isOutput=true]$MLFLOW_VERSION"
       name: mlflow_version

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,8 +39,12 @@ stages:
       ECR_REPOSITORY: "dna/mlflow"
     steps:
     - bash: |
-        MLFLOW_VERSION=$(grep -oP 'mlflow\[extras\]~=\K[0-9.]+' mlflow-image/pyproject.toml)
-        echo $MLFLOW_VERSION
+        MLFLOW_VERSION=$(grep -m1 -oP 'mlflow\[extras\]~=\K[0-9]+(\.[0-9]+)*' mlflow-image/pyproject.toml)
+        if [ -z "$MLFLOW_VERSION" ]; then
+          echo "Failed to extract MLflow version from mlflow-image/pyproject.toml" >&2
+          exit 1
+        fi
+        echo "$MLFLOW_VERSION"
         echo "##vso[task.setvariable variable=mlflow_tag;isOutput=true]$MLFLOW_VERSION"
       name: mlflow_version
       displayName: "Read MLflow version"


### PR DESCRIPTION
## What
The pipeline derived the ECR image tag from the `[project].version` field in
`mlflow-image/pyproject.toml`, which was decoupled from the mlflow version in an earlier commit
(`fb435a1`). As a result, builds pushed the project version (`1.0.0`) instead of
the mlflow version, so no `3.14.0` image was ever published.

## Change
Update the version extraction in `azure-pipelines.yml` to read the mlflow
version from the `mlflow[extras]~=X.Y.Z` dependency line:

    grep -oP 'mlflow\[extras\]~=\K[0-9.]+' mlflow-image/pyproject.toml

This now yields `3.14.0`.

## Note
The existing image is tagged `1.0.0` and is located in shared ECR.